### PR TITLE
Fix the expected value in testDateFormatApril25Var2.

### DIFF
--- a/test/TDFilterExpressionTests.m
+++ b/test/TDFilterExpressionTests.m
@@ -304,7 +304,7 @@
     TDNil(err);
     TDNotNil(expr);
     
-    NSString *expected = @"01996.April.25 AD 12:00PM";
+    NSString *expected = @"01996.April.25 AD 12:00 PM";
     NSString *actual = [expr evaluateAsStringInContext:ctx];
     TDEqualObjects(expected, actual);
 }


### PR DESCRIPTION
This test is currently failing.  The format string in this test has a space
between the :mm and aaa, so I'm pretty sure that the code under test is
behaving correctly, and it's just the expected string is wrong.

This was changed in cset 626a9248b8, but that was unrelated to the rest of
the change, so I think it was a simple mistake.